### PR TITLE
Remove reflections library. Fixes #19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ dependencies {
 
     // Framework
     compile group: 'net.dv8tion', name: 'JDA', version: '4.1.1_165'
-    compile group: 'org.reflections', name: 'reflections', version: '0.9.12'
     compile group: 'net.jodah', name: 'expiringmap', version: '0.5.8'
 
     // Data

--- a/src/main/java/net/notfab/lindsey/framework/command/CommandManager.java
+++ b/src/main/java/net/notfab/lindsey/framework/command/CommandManager.java
@@ -1,16 +1,14 @@
 package net.notfab.lindsey.framework.command;
 
 import lombok.Getter;
-import org.reflections.Reflections;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.ApplicationContext;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @Service
 public class CommandManager {
@@ -20,23 +18,15 @@ public class CommandManager {
 
     @Getter
     private final TaskExecutor pool;
-    private final ApplicationContext context;
     private final Map<String, Command> commandList = new HashMap<>();
 
-    public CommandManager(@Qualifier("commands") TaskExecutor pool, ApplicationContext context) {
+    public CommandManager(@Qualifier("commands") TaskExecutor pool, List<Command> commands) {
         Instance = this;
         this.pool = pool;
-        this.context = context;
-        this.findCommands().forEach(this::register);
+        commands.forEach(this::register);
     }
 
-    private Set<Class<? extends Command>> findCommands() {
-        Reflections reflections = new Reflections("net.notfab.lindsey.core.commands");
-        return reflections.getSubTypesOf(Command.class);
-    }
-
-    private void register(Class<? extends Command> clazz) {
-        Command command = context.getBean(clazz);
+    private void register(Command command) {
         CommandDescriptor descriptor = command.getInfo();
         this.commandList.put(descriptor.getName(), command);
         for (String alias : descriptor.getAliases()) {


### PR DESCRIPTION
This pull request removes the Reflections library from the bot. As described in #19 spring has a built-in way of doing this.

Fixes #19.

**Type**:
- [ ] New feature
- [X] Bug fix