### PR TITLE
Add privacy command

### DIFF
--- a/src/main/java/net/notfab/lindsey/core/commands/config/Privacy.java
+++ b/src/main/java/net/notfab/lindsey/core/commands/config/Privacy.java
@@ -1,0 +1,53 @@
+package net.notfab.lindsey.core.commands.config;
+
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.notfab.lindsey.framework.command.Bundle;
+import net.notfab.lindsey.framework.command.Command;
+import net.notfab.lindsey.framework.command.CommandDescriptor;
+import net.notfab.lindsey.framework.command.Modules;
+import net.notfab.lindsey.framework.command.help.HelpArticle;
+import net.notfab.lindsey.framework.command.help.HelpPage;
+import net.notfab.lindsey.framework.i18n.Messenger;
+import net.notfab.lindsey.framework.i18n.Translator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class Privacy implements Command {
+
+    @Autowired
+    private Translator i18n;
+
+    @Autowired
+    private Messenger msg;
+
+    @Override
+    public CommandDescriptor getInfo() {
+        return new CommandDescriptor.Builder()
+            .name("privacy")
+            .module(Modules.CORE)
+            .permission("commands.privacy", "permissions.command")
+            .build();
+    }
+
+    @Override
+    public boolean execute(Member member, TextChannel channel, String[] args, Message message, Bundle bundle) throws Exception {
+        msg.send(channel, sender(member) + i18n.get(member, "commands.core.privacy.link"));
+        return true;
+    }
+
+    @Override
+    public HelpArticle help(Member member) {
+        HelpPage page = new HelpPage("privacy")
+            .text("commands.core.privacy.description")
+            .usage("L!privacy")
+            .permission("commands.privacy")
+            .addExample("L!privacy");
+        return HelpArticle.of(page);
+    }
+
+}

--- a/src/main/resources/lang/en_US.toml
+++ b/src/main/resources/lang/en_US.toml
@@ -63,6 +63,9 @@ channel = "No channel named `{0}` found."
     unknown = "Unknown language."
     updated = "Language updated to {0}."
     target = "{0}'s preferred language is {1}."
+    [commands.core.privacy]
+    description = "Links to Lindsey's privacy policy."
+    link = "You can review our privacy policy at <https://notfab.net/Lindsey/privacy.txt>"
 
 [commands.fun]
     # Anime

--- a/src/test/java/net/notfab/lindsey/core/commands/config/PrivacyTest.java
+++ b/src/test/java/net/notfab/lindsey/core/commands/config/PrivacyTest.java
@@ -1,0 +1,44 @@
+package net.notfab.lindsey.core.commands.config;
+
+import net.notfab.lindsey.framework.command.CommandDescriptor;
+import net.notfab.lindsey.framework.command.Modules;
+import net.notfab.lindsey.framework.command.help.HelpArticle;
+import net.notfab.lindsey.framework.command.help.HelpPage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PrivacyTest {
+
+    private Privacy command;
+
+    @BeforeEach
+    void setUp() {
+        command = mock(Privacy.class);
+        when(command.getInfo())
+            .thenCallRealMethod();
+        when(command.help(null))
+            .thenCallRealMethod();
+    }
+
+    @Test
+    void getInfo() {
+        CommandDescriptor info = command.getInfo();
+        assertEquals("privacy", info.getName(), "Name must be privacy");
+        assertEquals(Modules.CORE, info.getModule(), "Module must be core");
+        assertTrue(info.getPermissions().stream()
+            .anyMatch(perm -> perm.getName().equals("commands." + info.getName())), "Must have permission with command name");
+    }
+
+    @Test
+    void help() {
+        HelpArticle article = command.help(null);
+        HelpPage page = article.get("privacy");
+        assertNotNull(page, "Help page must not be null");
+        assertEquals("commands." + command.getInfo().getName(), page.getPermission(), "Permission must be command name");
+    }
+
+}


### PR DESCRIPTION
Adds command that links to our privacy policy as required by Discord.

**Type**:
- [X] New feature
- [ ] Bug fix

**Command Checklist**:
- [X] No name conflict
- [X] Has permissions
- [X] Has documentation (help method)
- [X] Has all strings translated (at least en_US)
- [X] Added basic unit tests
