### PR TITLE
Little bug fix at Scramble class.

### DIFF
--- a/src/main/java/net/notfab/lindsey/core/commands/fun/Scramble.java
+++ b/src/main/java/net/notfab/lindsey/core/commands/fun/Scramble.java
@@ -95,7 +95,7 @@ public class Scramble implements Command {
         waiter.forMessage((m) -> m.getContentRaw().equalsIgnoreCase(word) && m.getTextChannel().equals(channel), TimeUnit.SECONDS.toMillis(60)).success((m) -> {
             long seconds = 60 - TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - time);
             int prize = (int) ((seconds * forSecond) + (word.length() * forCharacter));
-            msg.send(channel, i18n.get(member, "commands.economy.slot.win", prize));
+            msg.send(channel, "**" + member.getEffectiveName() + "**: " + i18n.get(member, "commands.economy.slot.win", prize));
             economy.pay(member, basePrize + prize);
             active.remove(id);
         }).timeout(() -> {


### PR DESCRIPTION
## Little bug fix at Scramble class.

So now, when you are playing scramble game, it should return your nickname (if you have one) instead of your username.

<img src="https://user-images.githubusercontent.com/77394398/109087730-c8505780-76ec-11eb-8ced-ed02d26df027.png" width="60%">

**Type**:
- [ ] New feature
- [x] Bug fix

**Command Checklist**:
- [ ] No name conflict
- [ ] Has permissions
- [ ] Has documentation (help method)
- [ ] Has all strings translated (at least en_US)
- [ ] Added basic unit tests
