### PR TITLE
Strike system

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     compile group: 'net.dv8tion', name: 'JDA', version: '4.2.0_228'
     compile group: 'com.sedmelluq', name: 'lavaplayer', version: '1.3.67'
     compile group: 'net.jodah', name: 'expiringmap', version: '0.5.8'
-    compile group: 'net.notfab.lindsey', name: 'shared', version: '0.1.9'
+    compile group: 'net.notfab.lindsey', name: 'shared', version: '0.1.12'
 
     // Data
     compile group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '2.6.0'

--- a/src/main/java/net/notfab/lindsey/core/commands/fun/Profile.java
+++ b/src/main/java/net/notfab/lindsey/core/commands/fun/Profile.java
@@ -20,8 +20,9 @@ import net.notfab.lindsey.shared.entities.items.Background;
 import net.notfab.lindsey.shared.entities.items.Badge;
 import net.notfab.lindsey.shared.entities.items.ItemReference;
 import net.notfab.lindsey.shared.entities.profile.UserProfile;
-import net.notfab.lindsey.shared.entities.profile.user.Customization;
+import net.notfab.lindsey.shared.entities.profile.user.UserCustomization;
 import net.notfab.lindsey.shared.enums.Flags;
+import net.notfab.lindsey.shared.repositories.sql.UserCustomizationRepository;
 import net.notfab.lindsey.shared.utils.Assets;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -63,6 +64,9 @@ public class Profile implements Command {
 
     @Autowired
     private ProfileManager profiles;
+
+    @Autowired
+    private UserCustomizationRepository customizationRepository;
 
     @Value("${bot.token}")
     private String token;
@@ -149,10 +153,12 @@ public class Profile implements Command {
         templateGraphics.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
         templateGraphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
-        Customization customization = profile.getCustomization();
+        UserCustomization customization = customizationRepository
+            .findById(user.getIdLong())
+            .orElse(new UserCustomization());
 
         // -- Add Header
-        if (customization != null) {
+        {
             Background reference = this.getBackground(user.getIdLong(), customization);
             if (reference != null) {
                 fontColor = GFXUtils.getColor(reference.getFontColor());
@@ -175,11 +181,11 @@ public class Profile implements Command {
         // -- Add account ribbon
         {
             BufferedImage image = null;
-            if ("87166524837613568".equals(profile.getId())) {
+            if (87166524837613568L == profile.getUser()) {
                 image = ImageIO.read(this.getResource("ribbons/developer.png"));
-            } else if ("119566649731842049".equals(profile.getId())) {
+            } else if (119566649731842049L == profile.getUser()) {
                 image = ImageIO.read(this.getResource("ribbons/designer.png"));
-            } else if ("119482224713269248".equals(profile.getId())) {
+            } else if (119482224713269248L == profile.getUser()) {
                 image = ImageIO.read(this.getResource("ribbons/official.png"));
             }
             if (image != null) {
@@ -193,8 +199,9 @@ public class Profile implements Command {
             if (country == null) {
                 country = Flags.Unknown;
             }
-            BufferedImage flag = country.getImage();
-            templateGraphics.drawImage(flag, 168, 39, null);
+            // TODO: Reimplement with assets from CDN
+            // BufferedImage flag = country.getImage();
+            // templateGraphics.drawImage(flag, 168, 39, null);
         }
 
         /* Badges
@@ -282,7 +289,7 @@ public class Profile implements Command {
         }
     }
 
-    private Background getBackground(long userId, Customization customization) {
+    private Background getBackground(long userId, UserCustomization customization) {
         Long backgroundId = customization.getBackground();
         if (backgroundId == null) {
             return null;

--- a/src/main/java/net/notfab/lindsey/core/commands/moderation/StrikesCmd.java
+++ b/src/main/java/net/notfab/lindsey/core/commands/moderation/StrikesCmd.java
@@ -1,0 +1,90 @@
+package net.notfab.lindsey.core.commands.moderation;
+
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.notfab.lindsey.core.framework.command.*;
+import net.notfab.lindsey.core.framework.command.help.HelpArticle;
+import net.notfab.lindsey.core.framework.command.help.HelpPage;
+import net.notfab.lindsey.core.framework.i18n.Messenger;
+import net.notfab.lindsey.core.framework.i18n.Translator;
+import net.notfab.lindsey.shared.entities.profile.member.Strike;
+import net.notfab.lindsey.shared.repositories.sql.StrikeRepository;
+import net.notfab.lindsey.shared.utils.Snowflake;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Optional;
+
+@Component
+public class StrikesCmd implements Command {
+
+    @Autowired
+    private Messenger msg;
+
+    @Autowired
+    private Translator i18n;
+
+    @Autowired
+    private StrikeRepository repository;
+
+    @Autowired
+    private Snowflake snowflake;
+
+    private final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+
+    @Override
+    public CommandDescriptor getInfo() {
+        return new CommandDescriptor.Builder()
+            .name("strikes")
+            .permission("commands.strikes", "permissions.command", false)
+            .module(Modules.MODERATION)
+            .build();
+    }
+
+    @Override
+    public boolean execute(Member member, TextChannel channel, String[] args, Message message, Bundle bundle) throws Exception {
+        if (args.length < 1) {
+            HelpArticle article = this.help(member);
+            article.send(channel, member, args, msg, i18n);
+        } else {
+            Member target = FinderUtil.findMember(argsToString(args, 0), message);
+            if (target == null) {
+                msg.send(channel, sender(member) + i18n.get(member, "core.member_nf"));
+                return false;
+            }
+
+            Optional<Strike> oStrike = this.repository
+                .findTopByUserAndGuildOrderByIdDesc(target.getIdLong(), target.getGuild().getIdLong());
+            if (oStrike.isEmpty()) {
+                msg.send(channel, sender(member) + i18n.get(member, "commands.mod.strikes.empty", target.getEffectiveName()));
+                return true;
+            }
+            Strike lastStrike = oStrike.get();
+
+            int strikes = this.repository
+                .sumByUserAndGuild(target.getIdLong(), member.getGuild().getIdLong());
+            String date = this.sdf.format(Instant
+                .ofEpochMilli(snowflake.parse(lastStrike.getId())[0]));
+            String admin = "<@!" + lastStrike.getAdmin() + ">";
+
+            msg.send(channel, sender(member) + i18n.get(member, "commands.mod.strikes.history",
+                target.getEffectiveName(), date, admin, strikes));
+        }
+        return true;
+    }
+
+    @Override
+    public HelpArticle help(Member member) {
+        HelpPage page = new HelpPage("strikes")
+            .text("commands.mod.strikes.description")
+            .usage("L!strikes <member>")
+            .url("https://github.com/LindseyBot/core/wiki/commands-strike#history")
+            .permission("commands.strikes")
+            .addExample("L!strikes @lindsey");
+        return HelpArticle.of(page);
+    }
+
+}

--- a/src/main/java/net/notfab/lindsey/core/framework/profile/ProfileManagerImpl.java
+++ b/src/main/java/net/notfab/lindsey/core/framework/profile/ProfileManagerImpl.java
@@ -5,10 +5,10 @@ import net.jodah.expiringmap.ExpirationListener;
 import net.jodah.expiringmap.ExpiringMap;
 import net.notfab.lindsey.core.repositories.mongo.MemberProfileRepository;
 import net.notfab.lindsey.core.repositories.mongo.ServerProfileRepository;
-import net.notfab.lindsey.core.repositories.mongo.UserProfileRepository;
 import net.notfab.lindsey.shared.entities.profile.MemberProfile;
 import net.notfab.lindsey.shared.entities.profile.ServerProfile;
 import net.notfab.lindsey.shared.entities.profile.UserProfile;
+import net.notfab.lindsey.shared.repositories.sql.UserProfileRepository;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 
@@ -69,11 +69,11 @@ public class ProfileManagerImpl implements ProfileManager, ExpirationListener<St
         if (this.userProfileCache.containsKey(id)) {
             return this.userProfileCache.get(id);
         }
-        Optional<UserProfile> oProfile = this.userRepository.findById(String.valueOf(id));
+        Optional<UserProfile> oProfile = this.userRepository.findById(id);
         UserProfile profile;
         if (oProfile.isEmpty()) {
             profile = new UserProfile();
-            profile.setId(String.valueOf(id));
+            profile.setUser(id);
         } else {
             profile = oProfile.get();
             this.userProfileCache.put(id, profile);
@@ -107,7 +107,7 @@ public class ProfileManagerImpl implements ProfileManager, ExpirationListener<St
     @Override
     public void save(@NotNull UserProfile profile) {
         userRepository.save(profile);
-        this.userProfileCache.remove(Long.parseLong(profile.getId()));
+        this.userProfileCache.remove(profile.getUser());
     }
 
     @Override

--- a/src/main/java/net/notfab/lindsey/core/repositories/mongo/UserProfileRepository.java
+++ b/src/main/java/net/notfab/lindsey/core/repositories/mongo/UserProfileRepository.java
@@ -1,8 +1,0 @@
-package net.notfab.lindsey.core.repositories.mongo;
-
-import net.notfab.lindsey.shared.entities.profile.UserProfile;
-import org.springframework.data.mongodb.repository.MongoRepository;
-
-public interface UserProfileRepository extends MongoRepository<UserProfile, String> {
-
-}

--- a/src/main/resources/lang/en_US.toml
+++ b/src/main/resources/lang/en_US.toml
@@ -257,8 +257,13 @@ not_enough = "Not enough items."
     description = "Strikes a user (warnings/punishments)"
     noreason = "No reason specified"
     interact = "This user is immune to strikes."
-    message = "You have received a strike in **{0}**. You now have a total of **{2}** strike(s).\nReason: `{1}`."
+    message = "You have received a strike in **{0}**.\nReason: `{1}`."
     striked = "User striked. Total strikes `{0}` [+{1}]."
+    # Strikes
+    [commands.mod.strikes]
+    description = "Lists a user's strike history."
+    history = "**{0}** was last striked in `{1}` by `{2}`, this user has `{3}` strikes."
+    empty = "**{0}** has a clean record in this server."
     # Softban
     [commands.mod.softban]
     description = "Softbans (ban+unban) a member from the guild, deleting all messages from that user for the past 7 days."

--- a/src/main/resources/lang/en_US.toml
+++ b/src/main/resources/lang/en_US.toml
@@ -68,7 +68,7 @@ page = "Page [{0}/{1}]"
 
 [automod]
     [automod.antiad]
-    ban = "Banned {0} for advertising."
+    reason = "Advertising"
     warn = "Hey {0}, advertising is not allowed here."
 
 [commands.core]

--- a/src/test/java/net/notfab/lindsey/core/commands/moderation/StrikeCmdTest.java
+++ b/src/test/java/net/notfab/lindsey/core/commands/moderation/StrikeCmdTest.java
@@ -11,13 +11,13 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class StrikeTest {
+class StrikeCmdTest {
 
-    private Strike command;
+    private StrikeCmd command;
 
     @BeforeEach
     void setUp() {
-        command = mock(Strike.class);
+        command = mock(StrikeCmd.class);
         when(command.getInfo())
             .thenCallRealMethod();
         when(command.help(null))

--- a/src/test/java/net/notfab/lindsey/core/commands/moderation/StrikesCmdTest.java
+++ b/src/test/java/net/notfab/lindsey/core/commands/moderation/StrikesCmdTest.java
@@ -1,0 +1,44 @@
+package net.notfab.lindsey.core.commands.moderation;
+
+import net.notfab.lindsey.core.framework.command.CommandDescriptor;
+import net.notfab.lindsey.core.framework.command.Modules;
+import net.notfab.lindsey.core.framework.command.help.HelpArticle;
+import net.notfab.lindsey.core.framework.command.help.HelpPage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class StrikesCmdTest {
+
+    private StrikesCmd command;
+
+    @BeforeEach
+    void setUp() {
+        command = mock(StrikesCmd.class);
+        when(command.getInfo())
+            .thenCallRealMethod();
+        when(command.help(null))
+            .thenCallRealMethod();
+    }
+
+    @Test
+    void getInfo() {
+        CommandDescriptor info = command.getInfo();
+        assertEquals("strikes", info.getName(), "Name must be strikes");
+        assertEquals(Modules.MODERATION, info.getModule(), "Module must be Moderation");
+        assertTrue(info.getPermissions().stream()
+            .anyMatch(perm -> perm.getName().equals("commands." + info.getName())), "Must have permission with command name");
+    }
+
+    @Test
+    void help() {
+        HelpArticle article = command.help(null);
+        HelpPage page = article.get("strikes");
+        assertNotNull(page, "Help page must not be null");
+        assertEquals("commands." + command.getInfo().getName(), page.getPermission(), "Permission must be command name");
+    }
+
+}


### PR DESCRIPTION
This pull request adds a strike system to control user strikes across all auto (and manually) moderation functions. This includes a fully-fledged system that holds a user's history for later check by moderators, as well as allowing future Actions to dynamically punish users for reaching certain thresholds.

**Type**:
- [X] New feature
- [ ] Bug fix

**Command Checklist**:
- [X] No name conflict
- [X] Has permissions
- [X] Has documentation (help method)
- [X] Has all strings translated (at least en_US)
- [X] Added basic unit tests
